### PR TITLE
Oqua separate database and Imports

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/di/AppDependencyGraph.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/di/AppDependencyGraph.kt
@@ -53,6 +53,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.VerbalizeViewMo
 import org.wycliffeassociates.otter.common.persistence.repositories.WorkbookRepository
 import org.wycliffeassociates.otter.jvm.device.ConfigureAudioSystem
 import org.wycliffeassociates.otter.jvm.workbookapp.oqua.ChapterViewModel
+import org.wycliffeassociates.otter.jvm.workbookapp.oqua.ImportViewModel
 
 @Component(
     modules = [
@@ -85,6 +86,7 @@ interface AppDependencyGraph {
     fun inject(viewModel: ChunkingViewModel)
     fun inject(viewModel: ExportChapterViewModel)
     fun inject(viewModel: ChapterViewModel)
+    fun inject(viewModel: ImportViewModel)
     fun injectDatabase(): AppDatabase
     fun injectDirectoryProvider(): IDirectoryProvider
     fun injectAppPreferencesRepository(): IAppPreferencesRepository

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
@@ -20,7 +20,6 @@ package org.wycliffeassociates.otter.jvm.workbookapp.oqua
 
 import com.jfoenix.controls.JFXSnackbar
 import com.jfoenix.controls.JFXSnackbarLayout
-import javafx.application.Platform
 import javafx.event.EventHandler
 import javafx.scene.input.DragEvent
 import javafx.scene.input.TransferMode
@@ -29,7 +28,6 @@ import javafx.util.Duration
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
-import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import tornadofx.*
@@ -40,6 +38,65 @@ class ImportView : View() {
 
     private val viewModel: ImportViewModel by inject()
 
+    private val importDialog = vbox {
+        visibleWhen(viewModel.showImportProperty)
+        managedWhen(visibleProperty())
+        text (
+            viewModel.importedProjectTitleProperty.stringBinding {
+                it?.let {
+                    MessageFormat.format(
+                        messages["importProjectTitle"],
+                        messages["import"],
+                        it
+                    )
+                } ?: messages["importResource"]
+            }
+        )
+        text(messages["importResourceMessage"])
+        text(messages["pleaseWait"])
+    }
+
+    private val successDialog = vbox {
+        visibleWhen(viewModel.showImportSuccessDialogProperty)
+        managedWhen(visibleProperty())
+        text (
+            viewModel.importedProjectTitleProperty.stringBinding {
+                it?.let {
+                    MessageFormat.format(
+                        messages["importProjectTitle"],
+                        messages["import"],
+                        it
+                    )
+                } ?: messages["importResource"]
+            }
+        )
+        text(messages["importResourceSuccessMessage"])
+    }
+
+    private val errorDialog = vbox {
+        visibleWhen(viewModel.showImportErrorDialogProperty)
+        managedWhen(visibleProperty())
+        text (
+            viewModel.importedProjectTitleProperty.stringBinding {
+                it?.let {
+                    MessageFormat.format(
+                        messages["importProjectTitle"],
+                        messages["import"],
+                        it
+                    )
+                } ?: messages["importResource"]
+            }
+        )
+        text(viewModel.importErrorMessage.stringBinding {
+            it ?: messages["importResourceFailMessage"]
+        })
+    }
+
+    override fun onDock() {
+        super.onDock()
+        viewModel.dock()
+    }
+
     override val root = vbox {
         addClass("app-drawer__content")
 
@@ -47,57 +104,64 @@ class ImportView : View() {
             addClass("app-drawer__scroll-pane")
             fitToParentHeight()
 
-            vbox {
-                isFitToWidth = true
-                isFitToHeight = true
+            borderpane {
+                center = vbox {
+                    isFitToWidth = true
+                    isFitToHeight = true
 
-                addClass("app-drawer-container")
+                    addClass("app-drawer-container")
 
-                hbox {
-                    label(messages["importFiles"]).apply {
-                        addClass("app-drawer__title")
-                    }
-                    region { hgrow = Priority.ALWAYS }
-                }
-
-                vbox {
-                    addClass("app-drawer__section")
-                    label(messages["dragAndDrop"]).apply {
-                        addClass("app-drawer__subtitle")
-                    }
-                }
-
-                vbox {
-                    addClass("app-drawer__drag-drop-area")
-
-                    vgrow = Priority.ALWAYS
-
-                    label {
-                        addClass("app-drawer__drag-drop-area__icon")
-                        graphic = FontIcon(MaterialDesign.MDI_FILE_MULTIPLE)
-                    }
-
-                    label(messages["dragToImport"]) {
-                        fitToParentWidth()
-                        addClass("app-drawer__text--centered")
-                    }
-
-                    button(messages["browseFiles"]) {
-                        addClass(
-                            "btn",
-                            "btn--primary"
-                        )
-                        tooltip {
-                            textProperty().bind(this@button.textProperty())
+                    hbox {
+                        label(messages["importFiles"]).apply {
+                            addClass("app-drawer__title")
                         }
-                        graphic = FontIcon(MaterialDesign.MDI_OPEN_IN_NEW)
-                        action {
-                            viewModel.onChooseFile()
+                        region { hgrow = Priority.ALWAYS }
+                    }
+
+                    vbox {
+                        addClass("app-drawer__section")
+                        label(messages["dragAndDrop"]).apply {
+                            addClass("app-drawer__subtitle")
                         }
                     }
 
-                    onDragOver = onDragOverHandler()
-                    onDragDropped = onDragDroppedHandler()
+                    vbox {
+                        addClass("app-drawer__drag-drop-area")
+
+                        vgrow = Priority.ALWAYS
+
+                        label {
+                            addClass("app-drawer__drag-drop-area__icon")
+                            graphic = FontIcon(MaterialDesign.MDI_FILE_MULTIPLE)
+                        }
+
+                        label(messages["dragToImport"]) {
+                            fitToParentWidth()
+                            addClass("app-drawer__text--centered")
+                        }
+
+                        button(messages["browseFiles"]) {
+                            addClass(
+                                "btn",
+                                "btn--primary"
+                            )
+                            tooltip {
+                                textProperty().bind(this@button.textProperty())
+                            }
+                            graphic = FontIcon(MaterialDesign.MDI_OPEN_IN_NEW)
+                            action {
+                                viewModel.onChooseFile()
+                            }
+                        }
+
+                        onDragOver = onDragOverHandler()
+                        onDragDropped = onDragDroppedHandler()
+                    }
+                }
+                right = vbox {
+                    add(importDialog)
+                    add(successDialog)
+                    add(errorDialog)
                 }
             }
         }
@@ -107,92 +171,7 @@ class ImportView : View() {
         tryImportStylesheet(resources["/css/app-drawer.css"])
         tryImportStylesheet(resources["/css/confirm-dialog.css"])
 
-        initImportDialog()
-        initSuccessDialog()
-        initErrorDialog()
         createSnackBar()
-    }
-
-    override fun onDock() {
-        super.onDock()
-    }
-
-    private fun initImportDialog() {
-        val importDialog = confirmdialog {
-            titleTextProperty.bind(
-                viewModel.importedProjectTitleProperty.stringBinding {
-                    it?.let {
-                        MessageFormat.format(
-                            messages["importProjectTitle"],
-                            messages["import"],
-                            it
-                        )
-                    } ?: messages["importResource"]
-                }
-            )
-            messageTextProperty.set(messages["importResourceMessage"])
-            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
-            progressTitleProperty.set(messages["pleaseWait"])
-            showProgressBarProperty.set(true)
-        }
-
-        viewModel.showImportDialogProperty.onChange {
-            Platform.runLater { if (it) importDialog.open() else importDialog.close() }
-        }
-    }
-
-    private fun initSuccessDialog() {
-        val successDialog = confirmdialog {
-            titleTextProperty.bind(
-                viewModel.importedProjectTitleProperty.stringBinding {
-                    it?.let {
-                        MessageFormat.format(
-                            messages["importProjectTitle"],
-                            messages["import"],
-                            it
-                        )
-                    } ?: messages["importResource"]
-                }
-            )
-            messageTextProperty.set(messages["importResourceSuccessMessage"])
-            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
-
-            cancelButtonTextProperty.set(messages["close"])
-            onCloseAction { viewModel.showImportSuccessDialogProperty.set(false) }
-            onCancelAction { viewModel.showImportSuccessDialogProperty.set(false) }
-        }
-
-        viewModel.showImportSuccessDialogProperty.onChange {
-            Platform.runLater { if (it) successDialog.open() else successDialog.close() }
-        }
-    }
-
-    private fun initErrorDialog() {
-        val errorDialog = confirmdialog {
-            titleTextProperty.bind(
-                viewModel.importedProjectTitleProperty.stringBinding {
-                    it?.let {
-                        MessageFormat.format(
-                            messages["importProjectTitle"],
-                            messages["import"],
-                            it
-                        )
-                    } ?: messages["importResource"]
-                }
-            )
-            messageTextProperty.bind(viewModel.importErrorMessage.stringBinding {
-                it ?: messages["importResourceFailMessage"]
-            })
-            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
-
-            cancelButtonTextProperty.set(messages["close"])
-            onCloseAction { viewModel.showImportErrorDialogProperty.set(false) }
-            onCancelAction { viewModel.showImportErrorDialogProperty.set(false) }
-        }
-
-        viewModel.showImportErrorDialogProperty.onChange {
-            Platform.runLater { if (it) errorDialog.open() else errorDialog.close() }
-        }
     }
 
     private fun onDragOverHandler(): EventHandler<DragEvent> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
@@ -1,0 +1,292 @@
+/**
+ * Copyright (C) 2020-2022 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.wycliffeassociates.otter.jvm.workbookapp.oqua
+
+import com.jfoenix.controls.JFXSnackbar
+import com.jfoenix.controls.JFXSnackbarLayout
+import javafx.application.Platform
+import javafx.event.EventHandler
+import javafx.scene.control.Button
+import javafx.scene.input.DragEvent
+import javafx.scene.input.KeyCode
+import javafx.scene.input.TransferMode
+import javafx.scene.layout.Priority
+import javafx.util.Duration
+import org.kordamp.ikonli.javafx.FontIcon
+import org.kordamp.ikonli.materialdesign.MaterialDesign
+import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
+import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.AddFilesViewModel
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewModel
+import tornadofx.*
+import java.text.MessageFormat
+
+class ImportView : View() {
+    private val logger = LoggerFactory.getLogger(ImportView::class.java)
+
+    private val viewModel: AddFilesViewModel by inject()
+    private val settingsViewModel: SettingsViewModel by inject()
+
+    private lateinit var closeButton: Button
+
+    override val root = vbox {
+        addClass("app-drawer__content")
+
+        scrollpane {
+            addClass("app-drawer__scroll-pane")
+            fitToParentHeight()
+
+            vbox {
+                isFitToWidth = true
+                isFitToHeight = true
+
+                addClass("app-drawer-container")
+
+                hbox {
+                    label(messages["importFiles"]).apply {
+                        addClass("app-drawer__title")
+                    }
+                    region { hgrow = Priority.ALWAYS }
+                    button {
+                        addClass("btn", "btn--secondary")
+                        graphic = FontIcon(MaterialDesign.MDI_CLOSE)
+                        tooltip(messages["close"])
+                        action { collapse() }
+                        closeButton = this
+                    }
+                }
+
+                vbox {
+                    addClass("app-drawer__section")
+                    label(messages["dragAndDrop"]).apply {
+                        addClass("app-drawer__subtitle")
+                    }
+
+                    textflow {
+                        text(messages["dragAndDropDescription"]).apply {
+                            addClass("app-drawer__text")
+                        }
+                        hyperlink("audio.bibleineverylanguage.org").apply {
+                            addClass("wa-text--hyperlink", "app-drawer__text--link")
+                            tooltip {
+                                text = "audio.bibleineverylanguage.org/gl"
+                            }
+                            action {
+                                hostServices.showDocument("https://audio.bibleineverylanguage.org/gl")
+                            }
+                        }
+                    }
+                }
+
+                vbox {
+                    addClass("app-drawer__drag-drop-area")
+
+                    vgrow = Priority.ALWAYS
+
+                    label {
+                        addClass("app-drawer__drag-drop-area__icon")
+                        graphic = FontIcon(MaterialDesign.MDI_FILE_MULTIPLE)
+                    }
+
+                    label(messages["dragToImport"]) {
+                        fitToParentWidth()
+                        addClass("app-drawer__text--centered")
+                    }
+
+                    button(messages["browseFiles"]) {
+                        addClass(
+                            "btn",
+                            "btn--primary"
+                        )
+                        tooltip {
+                            textProperty().bind(this@button.textProperty())
+                        }
+                        graphic = FontIcon(MaterialDesign.MDI_OPEN_IN_NEW)
+                        action {
+                            viewModel.onChooseFile()
+                        }
+                    }
+
+                    onDragOver = onDragOverHandler()
+                    onDragDropped = onDragDroppedHandler()
+                }
+            }
+        }
+
+        setOnKeyReleased {
+            if (it.code == KeyCode.ESCAPE) collapse()
+        }
+    }
+
+    init {
+        tryImportStylesheet(resources["/css/app-drawer.css"])
+        tryImportStylesheet(resources["/css/confirm-dialog.css"])
+
+        initImportDialog()
+        initSuccessDialog()
+        initErrorDialog()
+        createSnackBar()
+
+//        subscribe<DrawerEvent<UIComponent>> {
+//            if (it.action == DrawerEventAction.OPEN) {
+//                focusCloseButton()
+//            }
+//        }
+    }
+
+    override fun onDock() {
+        super.onDock()
+        focusCloseButton()
+    }
+
+    private fun initImportDialog() {
+        val importDialog = confirmdialog {
+            titleTextProperty.bind(
+                viewModel.importedProjectTitleProperty.stringBinding {
+                    it?.let {
+                        MessageFormat.format(
+                            messages["importProjectTitle"],
+                            messages["import"],
+                            it
+                        )
+                    } ?: messages["importResource"]
+                }
+            )
+            messageTextProperty.set(messages["importResourceMessage"])
+            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
+            progressTitleProperty.set(messages["pleaseWait"])
+            showProgressBarProperty.set(true)
+            orientationProperty.set(settingsViewModel.orientationProperty.value)
+            themeProperty.set(settingsViewModel.appColorMode.value)
+        }
+
+        viewModel.showImportDialogProperty.onChange {
+            Platform.runLater { if (it) importDialog.open() else importDialog.close() }
+        }
+    }
+
+    private fun initSuccessDialog() {
+        val successDialog = confirmdialog {
+            titleTextProperty.bind(
+                viewModel.importedProjectTitleProperty.stringBinding {
+                    it?.let {
+                        MessageFormat.format(
+                            messages["importProjectTitle"],
+                            messages["import"],
+                            it
+                        )
+                    } ?: messages["importResource"]
+                }
+            )
+            messageTextProperty.set(messages["importResourceSuccessMessage"])
+            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
+            orientationProperty.set(settingsViewModel.orientationProperty.value)
+            themeProperty.set(settingsViewModel.appColorMode.value)
+
+            cancelButtonTextProperty.set(messages["close"])
+            onCloseAction { viewModel.showImportSuccessDialogProperty.set(false) }
+            onCancelAction { viewModel.showImportSuccessDialogProperty.set(false) }
+        }
+
+        viewModel.showImportSuccessDialogProperty.onChange {
+            Platform.runLater { if (it) successDialog.open() else successDialog.close() }
+        }
+    }
+
+    private fun initErrorDialog() {
+        val errorDialog = confirmdialog {
+            titleTextProperty.bind(
+                viewModel.importedProjectTitleProperty.stringBinding {
+                    it?.let {
+                        MessageFormat.format(
+                            messages["importProjectTitle"],
+                            messages["import"],
+                            it
+                        )
+                    } ?: messages["importResource"]
+                }
+            )
+            messageTextProperty.bind(viewModel.importErrorMessage.stringBinding {
+                it ?: messages["importResourceFailMessage"]
+            })
+            backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
+            orientationProperty.set(settingsViewModel.orientationProperty.value)
+            themeProperty.set(settingsViewModel.appColorMode.value)
+
+            cancelButtonTextProperty.set(messages["close"])
+            onCloseAction { viewModel.showImportErrorDialogProperty.set(false) }
+            onCancelAction { viewModel.showImportErrorDialogProperty.set(false) }
+        }
+
+        viewModel.showImportErrorDialogProperty.onChange {
+            Platform.runLater { if (it) errorDialog.open() else errorDialog.close() }
+        }
+    }
+
+    private fun onDragOverHandler(): EventHandler<DragEvent> {
+        return EventHandler {
+            if (it.gestureSource != this && it.dragboard.hasFiles()) {
+                it.acceptTransferModes(TransferMode.COPY)
+            }
+            it.consume()
+        }
+    }
+
+    private fun onDragDroppedHandler(): EventHandler<DragEvent> {
+        return EventHandler {
+            var success = false
+            if (it.dragboard.hasFiles()) {
+                viewModel.onDropFile(it.dragboard.files)
+                success = true
+            }
+            it.isDropCompleted = success
+            it.consume()
+        }
+    }
+
+    private fun createSnackBar() {
+        viewModel
+            .snackBarObservable
+            .doOnError { e ->
+                logger.error("Error in creating add files snackbar", e)
+            }
+            .subscribe { pluginErrorMessage ->
+                SnackbarHandler.enqueue(
+                    JFXSnackbar.SnackbarEvent(
+                        JFXSnackbarLayout(pluginErrorMessage),
+                        Duration.millis(5000.0),
+                        null
+                    )
+                )
+            }
+    }
+
+    private fun focusCloseButton() {
+        runAsync {
+            Thread.sleep(500)
+            runLater(closeButton::requestFocus)
+        }
+    }
+
+    private fun collapse() {
+//        fire(DrawerEvent(this::class, DrawerEventAction.CLOSE))
+    }
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportView.kt
@@ -22,9 +22,7 @@ import com.jfoenix.controls.JFXSnackbar
 import com.jfoenix.controls.JFXSnackbarLayout
 import javafx.application.Platform
 import javafx.event.EventHandler
-import javafx.scene.control.Button
 import javafx.scene.input.DragEvent
-import javafx.scene.input.KeyCode
 import javafx.scene.input.TransferMode
 import javafx.scene.layout.Priority
 import javafx.util.Duration
@@ -34,18 +32,13 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.AddFilesViewModel
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewModel
 import tornadofx.*
 import java.text.MessageFormat
 
 class ImportView : View() {
     private val logger = LoggerFactory.getLogger(ImportView::class.java)
 
-    private val viewModel: AddFilesViewModel by inject()
-    private val settingsViewModel: SettingsViewModel by inject()
-
-    private lateinit var closeButton: Button
+    private val viewModel: ImportViewModel by inject()
 
     override val root = vbox {
         addClass("app-drawer__content")
@@ -65,34 +58,12 @@ class ImportView : View() {
                         addClass("app-drawer__title")
                     }
                     region { hgrow = Priority.ALWAYS }
-                    button {
-                        addClass("btn", "btn--secondary")
-                        graphic = FontIcon(MaterialDesign.MDI_CLOSE)
-                        tooltip(messages["close"])
-                        action { collapse() }
-                        closeButton = this
-                    }
                 }
 
                 vbox {
                     addClass("app-drawer__section")
                     label(messages["dragAndDrop"]).apply {
                         addClass("app-drawer__subtitle")
-                    }
-
-                    textflow {
-                        text(messages["dragAndDropDescription"]).apply {
-                            addClass("app-drawer__text")
-                        }
-                        hyperlink("audio.bibleineverylanguage.org").apply {
-                            addClass("wa-text--hyperlink", "app-drawer__text--link")
-                            tooltip {
-                                text = "audio.bibleineverylanguage.org/gl"
-                            }
-                            action {
-                                hostServices.showDocument("https://audio.bibleineverylanguage.org/gl")
-                            }
-                        }
                     }
                 }
 
@@ -130,10 +101,6 @@ class ImportView : View() {
                 }
             }
         }
-
-        setOnKeyReleased {
-            if (it.code == KeyCode.ESCAPE) collapse()
-        }
     }
 
     init {
@@ -144,17 +111,10 @@ class ImportView : View() {
         initSuccessDialog()
         initErrorDialog()
         createSnackBar()
-
-//        subscribe<DrawerEvent<UIComponent>> {
-//            if (it.action == DrawerEventAction.OPEN) {
-//                focusCloseButton()
-//            }
-//        }
     }
 
     override fun onDock() {
         super.onDock()
-        focusCloseButton()
     }
 
     private fun initImportDialog() {
@@ -174,8 +134,6 @@ class ImportView : View() {
             backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
             progressTitleProperty.set(messages["pleaseWait"])
             showProgressBarProperty.set(true)
-            orientationProperty.set(settingsViewModel.orientationProperty.value)
-            themeProperty.set(settingsViewModel.appColorMode.value)
         }
 
         viewModel.showImportDialogProperty.onChange {
@@ -198,8 +156,6 @@ class ImportView : View() {
             )
             messageTextProperty.set(messages["importResourceSuccessMessage"])
             backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
-            orientationProperty.set(settingsViewModel.orientationProperty.value)
-            themeProperty.set(settingsViewModel.appColorMode.value)
 
             cancelButtonTextProperty.set(messages["close"])
             onCloseAction { viewModel.showImportSuccessDialogProperty.set(false) }
@@ -228,8 +184,6 @@ class ImportView : View() {
                 it ?: messages["importResourceFailMessage"]
             })
             backgroundImageFileProperty.bind(viewModel.importedProjectCoverProperty)
-            orientationProperty.set(settingsViewModel.orientationProperty.value)
-            themeProperty.set(settingsViewModel.appColorMode.value)
 
             cancelButtonTextProperty.set(messages["close"])
             onCloseAction { viewModel.showImportErrorDialogProperty.set(false) }
@@ -277,16 +231,5 @@ class ImportView : View() {
                     )
                 )
             }
-    }
-
-    private fun focusCloseButton() {
-        runAsync {
-            Thread.sleep(500)
-            runLater(closeButton::requestFocus)
-        }
-    }
-
-    private fun collapse() {
-//        fire(DrawerEvent(this::class, DrawerEventAction.CLOSE))
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
@@ -47,7 +47,7 @@ class ImportViewModel : ViewModel() {
     @Inject lateinit var importRcProvider: Provider<ImportResourceContainer>
     @Inject lateinit var importProvider: Provider<ProjectImporter>
 
-    val showImportDialogProperty = SimpleBooleanProperty(false)
+    val showImportProperty = SimpleBooleanProperty(false)
     val showImportSuccessDialogProperty = SimpleBooleanProperty(false)
     val showImportErrorDialogProperty = SimpleBooleanProperty(false)
     val importErrorMessage = SimpleStringProperty(null)
@@ -58,6 +58,12 @@ class ImportViewModel : ViewModel() {
 
     init {
         (app as IDependencyGraphProvider).dependencyGraph.inject(this)
+    }
+
+    fun dock() {
+        showImportProperty.set(false)
+        showImportSuccessDialogProperty.set(false)
+        showImportErrorDialogProperty.set(false)
     }
 
     fun onDropFile(files: List<File>) {
@@ -84,7 +90,9 @@ class ImportViewModel : ViewModel() {
     }
 
     private fun importResourceContainer(file: File) {
-        showImportDialogProperty.set(true)
+        showImportProperty.set(true)
+        showImportSuccessDialogProperty.set(false)
+        showImportErrorDialogProperty.set(false)
 
         importRcProvider.get()
             .import(file)
@@ -100,17 +108,20 @@ class ImportViewModel : ViewModel() {
             .subscribe { result: ImportResult ->
                 when (result) {
                     ImportResult.SUCCESS -> {
+                        showImportProperty.value = false
                         showImportSuccessDialogProperty.value = true
                     }
                     ImportResult.DEPENDENCY_ERROR -> {
                         importErrorMessage.set(messages["importErrorDependencyExists"])
+                        showImportProperty.value = false
                         showImportErrorDialogProperty.value = true
                     }
                     else -> {
+                        showImportProperty.value = false
                         showImportErrorDialogProperty.value = true
                     }
                 }
-                showImportDialogProperty.value = false
+                showImportProperty.value = false
             }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2020-2022 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.wycliffeassociates.otter.jvm.workbookapp.oqua
+
+import com.github.thomasnield.rxkotlinfx.observeOnFx
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.property.SimpleStringProperty
+import javafx.stage.FileChooser
+import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.data.OratureFileFormat
+import org.wycliffeassociates.otter.common.data.primitives.ImageRatio
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.artwork.ArtworkAccessor
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.projectimportexport.ProjectImporter
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
+import org.wycliffeassociates.resourcecontainer.ResourceContainer
+import tornadofx.*
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Provider
+
+class ImportViewModel : ViewModel() {
+    private val logger = LoggerFactory.getLogger(ImportViewModel::class.java)
+
+    @Inject lateinit var directoryProvider: IDirectoryProvider
+    @Inject lateinit var importRcProvider: Provider<ImportResourceContainer>
+    @Inject lateinit var importProvider: Provider<ProjectImporter>
+
+    val showImportDialogProperty = SimpleBooleanProperty(false)
+    val showImportSuccessDialogProperty = SimpleBooleanProperty(false)
+    val showImportErrorDialogProperty = SimpleBooleanProperty(false)
+    val importErrorMessage = SimpleStringProperty(null)
+    val importedProjectTitleProperty = SimpleStringProperty()
+    val importedProjectCoverProperty = SimpleObjectProperty<File>()
+
+    val snackBarObservable: PublishSubject<String> = PublishSubject.create()
+
+    init {
+        (app as IDependencyGraphProvider).dependencyGraph.inject(this)
+    }
+
+    fun onDropFile(files: List<File>) {
+        if (isValidImportFile(files)) {
+            importResourceContainer(files.first())
+        }
+    }
+
+    fun onChooseFile() {
+        val file = chooseFile(
+            FX.messages["importResourceFromZip"],
+            arrayOf(
+                FileChooser.ExtensionFilter(
+                    messages["oratureFileTypes"],
+                    *OratureFileFormat.extensionList.map { "*.$it" }.toTypedArray()
+                )
+            ),
+            mode = FileChooserMode.Single
+        ).firstOrNull()
+        file?.let {
+            setProjectInfo(file)
+            importResourceContainer(file)
+        }
+    }
+
+    private fun importResourceContainer(file: File) {
+        showImportDialogProperty.set(true)
+
+        importRcProvider.get()
+            .import(file)
+            .subscribeOn(Schedulers.io())
+            .observeOnFx()
+            .doOnError { e ->
+                logger.error("Error in importing resource container $file", e)
+            }
+            .doFinally {
+                importedProjectTitleProperty.set(null)
+                importedProjectCoverProperty.set(null)
+            }
+            .subscribe { result: ImportResult ->
+                when (result) {
+                    ImportResult.SUCCESS -> {
+                        showImportSuccessDialogProperty.value = true
+                    }
+                    ImportResult.DEPENDENCY_ERROR -> {
+                        importErrorMessage.set(messages["importErrorDependencyExists"])
+                        showImportErrorDialogProperty.value = true
+                    }
+                    else -> {
+                        showImportErrorDialogProperty.value = true
+                    }
+                }
+                showImportDialogProperty.value = false
+            }
+    }
+
+    private fun isValidImportFile(files: List<File>): Boolean {
+        return when {
+            files.size > 1 -> {
+                snackBarObservable.onNext(messages["importMultipleError"])
+                false
+            }
+            files.first().isDirectory -> {
+                snackBarObservable.onNext(messages["importDirectoryError"])
+                false
+            }
+            files.first().extension !in OratureFileFormat.extensionList -> {
+                snackBarObservable.onNext(messages["importInvalidFileError"])
+                false
+            }
+            else -> true
+        }
+    }
+
+    private fun setProjectInfo(rc: File) {
+        try {
+            val project = ResourceContainer.load(rc, true).use { it.project() }
+            project?.let {
+                importProvider.get()
+                    .getSourceMetadata(rc)
+                    .doOnError {
+                        logger.debug("Error in getSourceMetadata: $rc")
+                    }
+                    .onErrorComplete()
+                    .subscribe { resourceMetadata ->
+                        resourceMetadata?.let {
+                            importedProjectTitleProperty.set(project.title)
+                            val coverArtAccessor = ArtworkAccessor(directoryProvider, it, project.identifier)
+                            importedProjectCoverProperty.set(
+                                coverArtAccessor.getArtwork(ImageRatio.FOUR_BY_ONE)?.file
+                            )
+                        }
+                    }
+            }
+        } catch (e: Exception) {
+            logger.error("Error in getting info from resource container $rc", e)
+        }
+    }
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/ImportViewModel.kt
@@ -22,13 +22,10 @@ import com.github.thomasnield.rxkotlinfx.observeOnFx
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.stage.FileChooser
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.data.OratureFileFormat
-import org.wycliffeassociates.otter.common.data.primitives.ImageRatio
-import org.wycliffeassociates.otter.common.domain.resourcecontainer.artwork.ArtworkAccessor
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.projectimportexport.ProjectImporter
@@ -52,7 +49,6 @@ class ImportViewModel : ViewModel() {
     val showImportErrorDialogProperty = SimpleBooleanProperty(false)
     val importErrorMessage = SimpleStringProperty(null)
     val importedProjectTitleProperty = SimpleStringProperty()
-    val importedProjectCoverProperty = SimpleObjectProperty<File>()
 
     val snackBarObservable: PublishSubject<String> = PublishSubject.create()
 
@@ -67,7 +63,7 @@ class ImportViewModel : ViewModel() {
     }
 
     fun onDropFile(files: List<File>) {
-        if (isValidImportFile(files)) {
+        if (validateImportFile(files)) {
             importResourceContainer(files.first())
         }
     }
@@ -103,7 +99,6 @@ class ImportViewModel : ViewModel() {
             }
             .doFinally {
                 importedProjectTitleProperty.set(null)
-                importedProjectCoverProperty.set(null)
             }
             .subscribe { result: ImportResult ->
                 when (result) {
@@ -125,7 +120,7 @@ class ImportViewModel : ViewModel() {
             }
     }
 
-    private fun isValidImportFile(files: List<File>): Boolean {
+    private fun validateImportFile(files: List<File>): Boolean {
         return when {
             files.size > 1 -> {
                 snackBarObservable.onNext(messages["importMultipleError"])
@@ -156,10 +151,6 @@ class ImportViewModel : ViewModel() {
                     .subscribe { resourceMetadata ->
                         resourceMetadata?.let {
                             importedProjectTitleProperty.set(project.title)
-                            val coverArtAccessor = ArtworkAccessor(directoryProvider, it, project.identifier)
-                            importedProjectCoverProperty.set(
-                                coverArtAccessor.getArtwork(ImageRatio.FOUR_BY_ONE)?.file
-                            )
                         }
                     }
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/LoadingView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/LoadingView.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2020-2022 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.wycliffeassociates.otter.jvm.workbookapp.oqua
+
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SplashScreenViewModel
+import tornadofx.*
+
+class LoadingView : View() {
+    private val viewModel: SplashScreenViewModel by inject()
+
+    override val root = stackpane {
+        addClass("splash__root")
+        add(resources.imageview("/orature_splash.png"))
+        progressbar(viewModel.progressProperty) {
+            addClass("splash__progress")
+            fitToParentWidth()
+        }
+    }
+
+    init {
+        tryImportStylesheet(resources["/css/common.css"])
+        tryImportStylesheet(resources["/css/splash-screen.css"])
+
+        viewModel
+            .initApp()
+            .subscribe(
+                {},
+                { finish() },
+                { finish() }
+            )
+    }
+
+    private fun finish() {
+        workspace.dock(find<HomeView>())
+    }
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/LoadingView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/LoadingView.kt
@@ -27,7 +27,6 @@ class LoadingView : View() {
 
     override val root = stackpane {
         addClass("splash__root")
-        add(resources.imageview("/orature_splash.png"))
         progressbar(viewModel.progressProperty) {
             addClass("splash__progress")
             fitToParentWidth()
@@ -49,5 +48,6 @@ class LoadingView : View() {
 
     private fun finish() {
         workspace.dock(find<HomeView>())
+        workspace.header.replaceWith(find<NavBar>().root)
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/NavBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/NavBar.kt
@@ -6,6 +6,7 @@ class NavBar : View() {
     private val viewModel: NavBarViewModel by inject()
 
     override val root = borderpane {
+
         center = hbox(5) {
             addClass("oqua-nav-bar")
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/NavBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/NavBar.kt
@@ -5,22 +5,33 @@ import tornadofx.*
 class NavBar : View() {
     private val viewModel: NavBarViewModel by inject()
 
-    override val root = hbox(5) {
-        addClass("oqua-nav-bar")
+    override val root = borderpane {
+        center = hbox(5) {
+            addClass("oqua-nav-bar")
 
-        button("OQuA") {
-            action {
-                workspace.dock(find<HomeView>())
+            button("OQuA") {
+                action {
+                    workspace.dock(find<HomeView>())
+                }
+            }
+            button(viewModel.projectTitleProperty){
+                visibleWhen(viewModel.projectTitleProperty.isNotNull)
+                action {
+                    workspace.dock(find<ProjectView>())
+                }
+            }
+            button(viewModel.chapterTitleProperty) {
+                visibleWhen(viewModel.chapterTitleProperty.isNotNull)
             }
         }
-        button(viewModel.projectTitleProperty){
-            visibleWhen(viewModel.projectTitleProperty.isNotNull)
-            action {
-                workspace.dock(find<ProjectView>())
+
+        right = hbox(5) {
+            addClass("oqua-nav-bar")
+            button("Import Resources") {
+                action {
+                    workspace.dock(find<ImportView>())
+                }
             }
-        }
-        button(viewModel.chapterTitleProperty) {
-            visibleWhen(viewModel.chapterTitleProperty.isNotNull)
         }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/OQuAView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/OQuAView.kt
@@ -12,7 +12,7 @@ class OQuAWorkspace : Workspace() {
 
     override fun onBeforeShow() {
         super.onDock()
-        workspace.dock(find<HomeView>())
+        workspace.dock(find<LoadingView>())
 
         workspace.header.replaceWith(find<NavBar>().root)
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/OQuAView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/OQuAView.kt
@@ -13,7 +13,5 @@ class OQuAWorkspace : Workspace() {
     override fun onBeforeShow() {
         super.onDock()
         workspace.dock(find<LoadingView>())
-
-        workspace.header.replaceWith(find<NavBar>().root)
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/TCardListCellFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/TCardListCellFragment.kt
@@ -49,7 +49,8 @@ class TCardListCellFragment: ListCellFragment<TranslationCard>() {
                     hostServices.showDocument(questionsURLProperty.value)
                 }
             }
-            text("Then open Orature and import the zip file you just downloaded.")
+            text("Then import that file using the button above.")
+            text("You will probably have to restart OQuA after doing so.")
         }
 
         listview<Workbook> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/TCardListCellFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/oqua/TCardListCellFragment.kt
@@ -50,7 +50,9 @@ class TCardListCellFragment: ListCellFragment<TranslationCard>() {
                 }
             }
             text("Then import that file using the button above.")
-            text("You will probably have to restart OQuA after doing so.")
+            text("You will probably have to restart OQuA after doing so.") {
+                addClass("oqua-missing-tq-header")
+            }
         }
 
         listview<Workbook> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
@@ -73,7 +73,8 @@ class DirectoryProvider(
             }
         }
 
-        pathComponents.add(appName)
+//        pathComponents.add(appName)
+        pathComponents.add("OQuA")
 
         if (appendedPath.isNotEmpty()) pathComponents.add(appendedPath)
 

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
@@ -54,11 +54,11 @@ class TestDirectoryProvider {
 
     val APPDATA_TESTS_TABLE = listOf<TestCase>(
         macParams + (EXPECT to
-                "/Users/edvin/Library/Application Support/Orature/database"),
+                "/Users/edvin/Library/Application Support/OQuA/database"),
         linuxParams + (EXPECT to
-                "/home/edvin/.config/Orature/database"),
+                "/home/edvin/.config/OQuA/database"),
         winParams + (EXPECT to
-                "C:\\Users\\Edvin\\AppData\\Roaming\\Orature\\database")
+                "C:\\Users\\Edvin\\AppData\\Roaming\\OQuA\\database")
     )
 
     val USERDATA_TESTS_TABLE = listOf<TestCase>(
@@ -72,20 +72,20 @@ class TestDirectoryProvider {
 
     val USERIMAGE_TESTS_TABLE = listOf<TestCase>(
         macParams + (EXPECT to
-                "/Users/edvin/Library/Application Support/Orature/users/images"),
+                "/Users/edvin/Library/Application Support/OQuA/users/images"),
         linuxParams + (EXPECT to
-                "/home/edvin/.config/Orature/users/images"),
+                "/home/edvin/.config/OQuA/users/images"),
         winParams + (EXPECT to
-                "C:\\Users\\Edvin\\AppData\\Roaming\\Orature\\users\\images")
+                "C:\\Users\\Edvin\\AppData\\Roaming\\OQuA\\users\\images")
     )
 
     val USERAUDIO_TESTS_TABLE = listOf<TestCase>(
         macParams + (EXPECT to
-                "/Users/edvin/Library/Application Support/Orature/users/audio"),
+                "/Users/edvin/Library/Application Support/OQuA/users/audio"),
         linuxParams + (EXPECT to
-                "/home/edvin/.config/Orature/users/audio"),
+                "/home/edvin/.config/OQuA/users/audio"),
         winParams + (EXPECT to
-                "C:\\Users\\Edvin\\AppData\\Roaming\\Orature\\users\\audio")
+                "C:\\Users\\Edvin\\AppData\\Roaming\\OQuA\\users\\audio")
     )
 
     private fun buildDirectoryProvider(testCase: TestCase) = DirectoryProvider(


### PR DESCRIPTION
OQuA now uses a different folder than Orature for its database. It still uses the public directories.
It will import the Orature projects upon startup and allows you to import resources as well.