### PR TITLE
Hot fix to update the database when Orature makes a change.

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -63,12 +63,17 @@ class InitializeProjects @Inject constructor(
                 log.info("$name up to date with version: $version")
             }
 
+            /**
+             * This is commented out so that it will always update the database.
+             * This is a hot fix, and it will be noted in JIRA as something to come back to.
+             *
             if (fetchProjects().isEmpty()) {
+             */
                 log.info("Importing projects...")
 
                 val dir = directoryProvider.getUserDataDirectory("/")
                 importProjects(dir)
-            }
+            /** } */
         }
     }
 


### PR DESCRIPTION
OQuA will now always update the database to the Orature public directories. This is necessary because it otherwise would not update to show that there is a new project.